### PR TITLE
バッファプールサイズの設定

### DIFF
--- a/etc/mysql/mysql.conf.d/mysqld.cnf
+++ b/etc/mysql/mysql.conf.d/mysqld.cnf
@@ -78,3 +78,6 @@ long_query_time = 0
 max_binlog_size   = 100M
 # binlog_do_db		= include_database_name
 # binlog_ignore_db	= include_database_name
+
+# バッファプールサイズの設定(free --humanの結果から計算)
+innodb_buffer_pool_size = 2G


### PR DESCRIPTION
`free --human`

```
               total        used        free      shared  buff/cache   available
Mem:           3.7Gi       858Mi       1.7Gi       2.8Mi       1.4Gi       2.9Gi
Swap:             0B          0B          0B
```

3.7Gi / 2 ≒ 2G